### PR TITLE
feat: add onToggle option, chore: BREAKING save map object

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -558,14 +558,16 @@
           startTab: 'tab-5',
         })
         .addTo(map);
-      const sidepanelRight = L.control.sidepanel('mySidepanelRight', {
-        panelPosition: 'right',
-        tabsPosition: 'top',
-        pushControls: true,
-        darkMode: true,
-        startTab: 2,
-      });
-      sidepanelRight.addTo(map);
+      const sidepanelRight = L.control
+        .sidepanel('mySidepanelRight', {
+          panelPosition: 'right',
+          tabsPosition: 'top',
+          pushControls: true,
+          darkMode: true,
+          startTab: 2,
+        })
+        .addTo(map);
+      sidepanelRight.open();
 
       L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution:

--- a/src/types/leaflet-sidepanel.ts
+++ b/src/types/leaflet-sidepanel.ts
@@ -12,12 +12,14 @@ declare module 'leaflet' {
     pushControls?: boolean;
     startTab?: number | string;
     onTabClick?: (tabLink: HTMLElement) => void;
+    onToggle?: (opened: boolean) => void;
   }
   namespace Control {
     class SidePanel extends L.Control {
       constructor(id: string, options?: SidePanelOptions);
       addTo(map: Map): this;
       toggle(map: Map, e?: Event): void;
+      isOpened(): boolean;
       open(map: Map): void;
       close(map: Map): void;
     }

--- a/src/types/leaflet-sidepanel.ts
+++ b/src/types/leaflet-sidepanel.ts
@@ -18,10 +18,10 @@ declare module 'leaflet' {
     class SidePanel extends L.Control {
       constructor(id: string, options?: SidePanelOptions);
       addTo(map: Map): this;
-      toggle(map: Map, e?: Event): void;
+      toggle(e?: Event): void;
       isOpened(): boolean;
-      open(map: Map): void;
-      close(map: Map): void;
+      open(): void;
+      close(): void;
     }
   }
   namespace control {


### PR DESCRIPTION
closes #6

- feat: add onToggle option
- chore: some ts improvments
- chore: BREAKING don't pass map object to each method
    - Migration Guide: remove all map instanced from the `toggle`, `open` and `close` method